### PR TITLE
Add script path prefix to jenkins-call-url command

### DIFF
--- a/scripts/upgrade/env.sh
+++ b/scripts/upgrade/env.sh
@@ -8,7 +8,7 @@ if [ -f build.gradle ]; then
   [ -z "${FORCE_UPGRADE}" ] && export JENKINS_USER="admin" || export JENKINS_USER="${JENKINS_USER:-admin}"
   export JENKINS_PASSWORD="${JENKINS_PASSWORD:-$(<"${JENKINS_HOME}"/secrets/initialAdminPassword)}"
   unset JENKINS_CALL_ARGS
-  jenkins-call-url -a -v -v "${JENKINS_WEB}"/api/json -o /dev/null
+  "${SCRIPT_LIBARY_PATH}"/jenkins-call-url -a -v -v "${JENKINS_WEB}"/api/json -o /dev/null
   export JENKINS_CALL_ARGS="-m POST ${JENKINS_WEB}/scriptText --data-string script= -d"
 else
   echo "Not in repository root." 1>&2


### PR DESCRIPTION
This resolves an issue where the jenkins-call-url command
is not found when the env.sh file is source from other
scripts.