### PR TITLE
Add missing import

### DIFF
--- a/scripts/configure-disable-usage-stats.groovy
+++ b/scripts/configure-disable-usage-stats.groovy
@@ -19,6 +19,8 @@
    An option like this shouldn't be enabled by default.
  */
 
+import jenkins.model.Jenkins
+
 def j = Jenkins.instance
 if(!j.isQuietingDown()) {
     if(j.isUsageStatisticsCollected()){


### PR DESCRIPTION
Fixes the following exception when run:
```
WARNING: Failed to run script file:/var/lib/jenkins/init.groovy.d/configure-disable-usage-stats.groovy
groovy.lang.MissingPropertyException: No such property: Jenkins for class: configure-disable-usage-stats
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)
	at org.codehaus.groovy.runtime.callsite.PogoGetPropertySite.getProperty(PogoGetPropertySite.java:52)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:307)
	at configure-disable-usage-stats.run(configure-disable-usage-stats.groovy:22)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:585)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:127)
	at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:110)
	at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1064)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```